### PR TITLE
Feature: Be able to ‘share’ environment with internal network using ishi

### DIFF
--- a/develop
+++ b/develop
@@ -90,6 +90,25 @@ if [ $# -gt 0 ];then
             -w /var/www/html \
             node \
             ./node_modules/.bin/gulp "$@"
+
+    # If "share" is used, run ishi to share
+    elif [ "$1" == "share" ]; then
+        shift 1
+
+        GREEN='\033[00;32m' YELLOW='\033[11;33m' NORMAL='\033[0m' RED='\033[0;31m'
+
+        echo -e "${RED}Ishi is required for this to work correctly (https://github.com/suin/ishi)${NORMAL}"
+        echo -e "IP for mobile use after setup: ${GREEN}${XDEBUG_HOST}${NORMAL}"
+
+        DOMAIN=${1:-"browsersync.$(echo `basename $PWD`).docker"}
+        PORT=${2:-3000}
+
+        echo -e "\n${GREEN}Visit http://${XDEBUG_HOST}:${PORT}${NORMAL}"
+
+        echo -e "${YELLOW}"
+        sudo ${HOME}/go/bin/ishi --listen ${PORT} http://${DOMAIN}:${2:-$PORT}
+        echo -e "${NORMAL}"
+
     else
         $COMPOSE "$@"
     fi

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -72,6 +72,15 @@ services:
       MYSQL_USER: "${DB_USER}"
       MYSQL_PASSWORD: "${DB_PASS}"
 
+  browsersync:
+    image: ustwo/browser-sync:latest
+    command: start --proxy "REPLACE_THIS_WITH_FQDN" --files "public/css/*.css"
+    volumes:
+      - ./:/source
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+
   node:
     extends:
       file: docker-compose.base.yml


### PR DESCRIPTION
This PR makes it possible to easily share docker containers with your interal network.
Usage:

```bash
develop share
```

Or to customize address + port

```bash
develop share iwanttosharethis.docker 8080
```
